### PR TITLE
Fix setup py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='lexicamaker',
                    'Programming Language :: Python :: 3.7',
                    'Topic :: Text Processing :: Linguistic',
                    ],
-  keywords='dsl apple dictionary'
+  keywords='dsl apple dictionary',
   url='http://github.com/lnxk/adsmaker',
   author='Svintuss',
   author_email='svintuss@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name='lexicamaker',
   license='MIT',
   packages=['lexicamaker'],
   zip_safe=True,
-  include_package_data=True
+  include_package_data=True,
   entry_points = {
     'console_scripts': ['adsmaker=lexicamaker.__main__:main'],
   }


### PR DESCRIPTION
```shell
~  15s
$ pipx install git+https://github.com/Bobronium/lexicamaker.git@fix-setup-py
  installed package lexicamaker 0.1.2, installed using Python 3.10.1
  These apps are now globally available
    - adsmaker
done! ✨ 🌟 ✨

~  31s
$ adsmaker
usage: adsmaker [-h] [-v] [--annotation FILE | --no-annotation] [--abbreviations FILE | --no-abbreviations] [--name NAME]
                [--encoding ENCODING] [--version] [--remote]
                DSL_FILE [OUTPUT_DIR]
adsmaker: error: the following arguments are required: DSL_FILE
```